### PR TITLE
chore: Update sigstore refs to rhtas

### DIFF
--- a/bundle/manifests/policy-controller-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/policy-controller-operator.clusterserviceversion.yaml
@@ -2,16 +2,148 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[]'
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "rhtas.charts.redhat.com/v1alpha1",
+          "kind": "PolicyController",
+          "metadata": {
+            "name": "policycontroller-sample"
+          },
+          "spec": {
+            "commonAnnotations": {},
+            "commonNodeSelector": {},
+            "commonTolerations": [],
+            "cosign": {
+              "cosignPub": "",
+              "webhookName": "policy.rhtas.dev",
+              "webhookTimeoutSeconds": {}
+            },
+            "imagePullSecrets": [],
+            "installCRDs": true,
+            "leasescleanup": {
+              "automountServiceAccountToken": true,
+              "image": {
+                "pullPolicy": "IfNotPresent",
+                "repository": "cgr.dev/chainguard/kubectl",
+                "version": "latest-dev"
+              },
+              "podSecurityContext": {
+                "enabled": false
+              },
+              "priorityClass": "",
+              "resources": {
+                "limits": {
+                  "cpu": "",
+                  "memory": ""
+                },
+                "requests": {
+                  "cpu": "",
+                  "memory": ""
+                }
+              }
+            },
+            "loglevel": "info",
+            "serviceMonitor": {
+              "enabled": false
+            },
+            "webhook": {
+              "affinity": {},
+              "automountServiceAccountToken": true,
+              "configData": {},
+              "customLabels": {},
+              "env": {},
+              "envFrom": {},
+              "failurePolicy": "Fail",
+              "image": {
+                "pullPolicy": "IfNotPresent",
+                "repository": "quay.io/securesign/policy-controller",
+                "version": "sha256:77ea7af66c7b323e746ce2b783ef63c590307e04a9136af7b8d527e53c7b96cd"
+              },
+              "name": "webhook",
+              "namespaceSelector": {
+                "matchExpressions": [
+                  {
+                    "key": "policy.rhtas.dev/include",
+                    "operator": "In",
+                    "values": [
+                      "true"
+                    ]
+                  }
+                ]
+              },
+              "podAnnotations": {},
+              "podDisruptionBudget": {
+                "enabled": true,
+                "minAvailable": 1
+              },
+              "podSecurityContext": {
+                "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": [
+                    "ALL"
+                  ]
+                },
+                "enabled": true,
+                "readOnlyRootFilesystem": true,
+                "runAsNonRoot": true,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "priorityClass": "",
+              "registryCaBundle": {},
+              "replicaCount": 1,
+              "resources": {
+                "limits": {
+                  "cpu": "200m",
+                  "memory": "512Mi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "128Mi"
+                }
+              },
+              "securityContext": {
+                "runAsNonRoot": true,
+                "seccompProfile": {
+                  "type": "RuntimeDefault"
+                }
+              },
+              "service": {
+                "annotations": {},
+                "port": 443,
+                "type": "ClusterIP"
+              },
+              "serviceAccount": {
+                "annotations": {},
+                "create": true,
+                "name": ""
+              },
+              "volumeMounts": [],
+              "volumes": [],
+              "webhookNames": {
+                "defaulting": "defaulting.clusterimagepolicy.rhtas.dev",
+                "validating": "validating.clusterimagepolicy.rhtas.dev"
+              },
+              "webhookTimeoutSeconds": {}
+            }
+          }
+        }
+      ]
     capabilities: Basic Install
-    createdAt: "2025-05-08T11:56:17Z"
+    createdAt: "2025-05-12T11:37:10Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
   name: policy-controller-operator.v0.0.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
-  customresourcedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: PolicyController
+      name: policycontrollers.rhtas.charts.redhat.com
+      version: v1alpha1
   description: rhtas-policy-controller
   displayName: rhtas-policy-controller
   icon:
@@ -19,7 +151,192 @@ spec:
     mediatype: ""
   install:
     spec:
-      deployments: []
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+        - apiGroups:
+          - rhtas.charts.redhat.com
+          resources:
+          - policycontrollers
+          - policycontrollers/status
+          - policycontrollers/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - '*'
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - '*'
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - '*'
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: policy-controller-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: policy-controller-operator
+          control-plane: controller-manager
+        name: policy-controller-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --metrics-require-rbac
+                - --metrics-secure
+                - --metrics-bind-address=:8443
+                - --leader-elect
+                - --leader-election-id=policy-controller-operator
+                - --health-probe-bind-address=:8081
+                image: img:latest
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: policy-controller-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: policy-controller-operator-controller-manager
     strategy: deployment
   installModes:
   - supported: true

--- a/bundle/manifests/rhtas.charts.redhat.com_policycontrollers.yaml
+++ b/bundle/manifests/rhtas.charts.redhat.com_policycontrollers.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: policycontrollers.rhtas.charts.redhat.com
+spec:
+  group: rhtas.charts.redhat.com
+  names:
+    kind: PolicyController
+    listKind: PolicyControllerList
+    plural: policycontrollers
+    singular: policycontroller
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PolicyController is the Schema for the policycontrollers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of PolicyController
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of PolicyController
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,4 @@
 ## Append samples of your project ##
 resources:
-- charts_v1alpha1_policycontroller.yaml
+- rhtas.charts_v1alpha1_policycontroller.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/rhtas.charts_v1alpha1_policycontroller.yaml
+++ b/config/samples/rhtas.charts_v1alpha1_policycontroller.yaml
@@ -9,7 +9,7 @@ spec:
   commonTolerations: []
   cosign:
     cosignPub: ""
-    webhookName: policy.sigstore.dev
+    webhookName: policy.rhtas.dev
     webhookTimeoutSeconds: {}
   imagePullSecrets: []
   installCRDs: true
@@ -39,7 +39,6 @@ spec:
     customLabels: {}
     env: {}
     envFrom: {}
-    extraArgs: {}
     failurePolicy: Fail
     image:
       pullPolicy: IfNotPresent
@@ -48,7 +47,7 @@ spec:
     name: webhook
     namespaceSelector:
       matchExpressions:
-      - key: policy.sigstore.dev/include
+      - key: policy.rhtas.dev/include
         operator: In
         values:
         - "true"
@@ -91,8 +90,8 @@ spec:
     volumeMounts: []
     volumes: []
     webhookNames:
-      defaulting: defaulting.clusterimagepolicy.sigstore.dev
-      validating: validating.clusterimagepolicy.sigstore.dev
+      defaulting: defaulting.clusterimagepolicy.rhtas.dev
+      validating: validating.clusterimagepolicy.rhtas.dev
     webhookTimeoutSeconds: {}
   
   

--- a/helm-charts/policy-controller/Chart.yaml
+++ b/helm-charts/policy-controller/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   artifacthub.io/images: |
     - name: policy-controller
-      image: ghcr.io/sigstore/policy-controller/policy-controller:v0.12.0@sha256:6b51f336dec9e9adff29606855dbd2c7910c5eb80d6579795a29cb3844428efc
+      image: quay.io/securesign/policy-controller@sha256:77ea7af66c7b323e746ce2b783ef63c590307e04a9136af7b8d527e53c7b96cd
   artifacthub.io/license: Apache-2.0
 apiVersion: v2
 appVersion: 0.12.0

--- a/helm-charts/policy-controller/templates/_helpers.tpl
+++ b/helm-charts/policy-controller/templates/_helpers.tpl
@@ -134,7 +134,7 @@ Create the image path for the passed in leases-cleanup image field
 {{ toYaml .Values.webhook.namespaceSelector }}
 {{- else }}
 matchExpressions:
-  - key: policy.sigstore.dev/include
+  - key: policy.rhtas.dev/include
     operator: In
     values: ["true"]
 {{- end }}

--- a/helm-charts/policy-controller/templates/webhook/deployment_webhook.yaml
+++ b/helm-charts/policy-controller/templates/webhook/deployment_webhook.yaml
@@ -93,17 +93,10 @@ spec:
             name: "{{ $secretName }}"
 {{- end }}
 {{- end }}
-        {{- if or (semverCompare ">= 1.8-0" .Chart.AppVersion) .Values.webhook.extraArgs }}
         args:
-        {{- if semverCompare ">= 1.8-0" .Chart.AppVersion }}
         - -webhook-name={{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName }}
         - -mutating-webhook-name={{ required "A valid webhook.webhookNames.defaulting is required" .Values.webhook.webhookNames.defaulting }}
         - -validating-webhook-name={{ required "A valid webhook.webhookNames.validating is required" .Values.webhook.webhookNames.validating }}
-        {{- end }}
-        {{- range $key, $value := .Values.webhook.extraArgs }}
-        - -{{ $key }}={{ $value }}
-        {{- end }}
-        {{- end }}
         ports:
         - containerPort: 8443
           name: https

--- a/helm-charts/policy-controller/values.yaml
+++ b/helm-charts/policy-controller/values.yaml
@@ -1,7 +1,7 @@
 cosign:
   # add the values in base64 encoded
   cosignPub: ""
-  webhookName: "policy.sigstore.dev"
+  webhookName: "policy.rhtas.dev"
   webhookTimeoutSeconds: {}
     # mutating: 10
     # validating: 10
@@ -29,7 +29,6 @@ webhook:
     # secrets:
     #   - mys1
     #   - mys2
-  extraArgs: {}
   resources:
     limits:
       cpu: 200m
@@ -75,13 +74,13 @@ webhook:
   volumes: []
   namespaceSelector:
     matchExpressions:
-      - key: policy.sigstore.dev/include
+      - key: policy.rhtas.dev/include
         operator: In
         values: ["true"]
   registryCaBundle: {}
   webhookNames:
-    defaulting: "defaulting.clusterimagepolicy.sigstore.dev"
-    validating: "validating.clusterimagepolicy.sigstore.dev"
+    defaulting: "defaulting.clusterimagepolicy.rhtas.dev"
+    validating: "validating.clusterimagepolicy.rhtas.dev"
   webhookTimeoutSeconds: {}
     # defaulting: 10
     # validating: 10


### PR DESCRIPTION
Small pr to update default values to RHTAS specific ones and runs make bundle.

## Summary by Sourcery

Update default configuration values and CRD references to RHTAS-specific domains and regenerate the operator bundle.

Enhancements:
- Replace sigstore domains in Cosign webhookName, namespace selector key, and webhookNames with rhtas.dev equivalents in Helm values and samples
- Update the policy-controller image reference to quay.io/securesign with the latest sha256 digest
- Add a new PolicyController CustomResourceDefinition under the rhtas.charts.redhat.com group
- Regenerate the CSV and bundle manifests (via make bundle) to include updated defaults and CRD definitions