### PR TITLE
build: Simplfy sample api def

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ bin
 *.swp
 *.swo
 *~
+
+# testing
+CatalogSource.yaml

--- a/bundle/manifests/policy-controller-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/policy-controller-operator.clusterserviceversion.yaml
@@ -5,57 +5,62 @@ metadata:
     alm-examples: |-
       [
         {
+          "apiVersion": "policy.sigstore.dev/v1alpha1",
+          "kind": "TrustRoot",
+          "metadata": {
+            "name": "trust-root"
+          },
+          "spec": {
+            "remote": {
+              "mirror": "https://tuf.example.com",
+              "root": "\u003cbase64 encode trust root\u003e"
+            }
+          }
+        },
+        {
+          "apiVersion": "policy.sigstore.dev/v1beta1",
+          "kind": "ClusterImagePolicy",
+          "metadata": {
+            "name": "cluster-image-policy"
+          },
+          "spec": {
+            "authorities": [
+              {
+                "ctlog": {
+                  "trustRootRef": "trust-root-ref",
+                  "url": "https://rekor.example.com"
+                },
+                "keyless": {
+                  "identities": [
+                    {
+                      "issuer": "https://oidc.example.com",
+                      "subject": "oidc-issuer-subject"
+                    }
+                  ],
+                  "trustRootRef": "trust-root-ref",
+                  "url": "https://fulcio.example.com"
+                }
+              }
+            ],
+            "images": [
+              {
+                "glob": "**"
+              }
+            ]
+          }
+        },
+        {
           "apiVersion": "rhtas.charts.redhat.com/v1alpha1",
           "kind": "PolicyController",
           "metadata": {
-            "name": "policycontroller-sample",
-            "namespace": "policy-controller-operator"
+            "name": "policycontroller-sample"
           },
           "spec": {
             "policy-controller": {
-              "commonAnnotations": {},
-              "commonNodeSelector": {},
-              "commonTolerations": [],
               "cosign": {
-                "cosignPub": "",
-                "webhookName": "policy.rhtas.com",
-                "webhookTimeoutSeconds": {}
-              },
-              "imagePullSecrets": [],
-              "installCRDs": true,
-              "leasescleanup": {
-                "automountServiceAccountToken": true,
-                "image": {
-                  "pullPolicy": "IfNotPresent",
-                  "repository": "cgr.dev/chainguard/kubectl",
-                  "version": "latest-dev"
-                },
-                "podSecurityContext": {
-                  "enabled": false
-                },
-                "priorityClass": "",
-                "resources": {
-                  "limits": {
-                    "cpu": "",
-                    "memory": ""
-                  },
-                  "requests": {
-                    "cpu": "",
-                    "memory": ""
-                  }
-                }
-              },
-              "loglevel": "info",
-              "serviceMonitor": {
-                "enabled": false
+                "webhookName": "policy.rhtas.com"
               },
               "webhook": {
-                "affinity": {},
-                "automountServiceAccountToken": true,
-                "configData": {},
-                "customLabels": {},
-                "env": {},
-                "envFrom": {},
                 "extraArgs": {
                   "mutating-webhook-name": "defaulting.clusterimagepolicy.rhtas.com",
                   "validating-webhook-name": "validating.clusterimagepolicy.rhtas.com",
@@ -74,41 +79,10 @@ metadata:
                     }
                   ]
                 },
-                "podAnnotations": {},
-                "podDisruptionBudget": {
-                  "enabled": true,
-                  "minAvailable": 1
-                },
-                "priorityClass": "",
-                "registryCaBundle": {},
-                "replicaCount": 1,
-                "resources": {
-                  "limits": {
-                    "cpu": "200m",
-                    "memory": "512Mi"
-                  },
-                  "requests": {
-                    "cpu": "100m",
-                    "memory": "128Mi"
-                  }
-                },
-                "service": {
-                  "annotations": {},
-                  "port": 443,
-                  "type": "ClusterIP"
-                },
-                "serviceAccount": {
-                  "annotations": {},
-                  "create": true,
-                  "name": ""
-                },
-                "volumeMounts": [],
-                "volumes": [],
                 "webhookNames": {
                   "defaulting": "defaulting.clusterimagepolicy.rhtas.com",
                   "validating": "validating.clusterimagepolicy.rhtas.com"
-                },
-                "webhookTimeoutSeconds": {}
+                }
               }
             }
           }
@@ -116,7 +90,7 @@ metadata:
       ]
     capabilities: Basic Install
     containerImage: placeholder
-    createdAt: "2025-05-16T07:56:27Z"
+    createdAt: "2025-05-28T07:36:48Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,6 @@
 ## Append samples of your project ##
 resources:
 - rhtas.charts_v1alpha1_policycontroller.yaml
+- rhtas.charts_v1alpha1_clusterimagepolicy.yaml
+- rhtas.charts_v1alpha1_trustroot.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/rhtas.charts_v1alpha1_clusterimagepolicy.yaml
+++ b/config/samples/rhtas.charts_v1alpha1_clusterimagepolicy.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: cluster-image-policy
+spec:
+  images:
+    - glob: "**"
+  authorities:
+    - keyless:
+        url: https://fulcio.example.com
+        trustRootRef: trust-root-ref
+        identities:
+          - issuer: https://oidc.example.com
+            subject: oidc-issuer-subject
+      ctlog:
+        url: https://rekor.example.com
+        trustRootRef: trust-root-ref

--- a/config/samples/rhtas.charts_v1alpha1_policycontroller.yaml
+++ b/config/samples/rhtas.charts_v1alpha1_policycontroller.yaml
@@ -2,82 +2,22 @@ apiVersion: rhtas.charts.redhat.com/v1alpha1
 kind: PolicyController
 metadata:
   name: policycontroller-sample
-  namespace: policy-controller-operator
 spec:
   policy-controller:
-    # Default values copied from <project_dir>/helm-charts/policy-controller/values.yaml
-    commonAnnotations: {}
-    commonNodeSelector: {}
-    commonTolerations: []
     cosign:
-      cosignPub: ""
       webhookName: "policy.rhtas.com"
-      webhookTimeoutSeconds: {}
-    imagePullSecrets: []
-    installCRDs: true
-    leasescleanup:
-      automountServiceAccountToken: true
-      image:
-        pullPolicy: IfNotPresent
-        repository: cgr.dev/chainguard/kubectl
-        version: latest-dev
-      podSecurityContext:
-        enabled: false
-      priorityClass: ""
-      resources:
-        limits:
-          cpu: ""
-          memory: ""
-        requests:
-          cpu: ""
-          memory: ""
-    loglevel: info
-    serviceMonitor:
-      enabled: false
     webhook:
-      affinity: {}
-      automountServiceAccountToken: true
-      configData: {}
-      customLabels: {}
-      env: {}
-      envFrom: {}
+      name: webhook
       extraArgs:
         webhook-name: policy.rhtas.com
         mutating-webhook-name: defaulting.clusterimagepolicy.rhtas.com
         validating-webhook-name: validating.clusterimagepolicy.rhtas.com
       failurePolicy: Fail
-      name: webhook
       namespaceSelector:
         matchExpressions:
-        - key: policy.rhtas.com/include
-          operator: In
-          values:
-          - "true"
-      podAnnotations: {}
-      podDisruptionBudget:
-        enabled: true
-        minAvailable: 1
-      priorityClass: ""
-      registryCaBundle: {}
-      replicaCount: 1
-      resources:
-        limits:
-          cpu: 200m
-          memory: 512Mi
-        requests:
-          cpu: 100m
-          memory: 128Mi
-      service:
-        annotations: {}
-        port: 443
-        type: ClusterIP
-      serviceAccount:
-        annotations: {}
-        create: true
-        name: ""
-      volumeMounts: []
-      volumes: []
+          - key: policy.rhtas.com/include
+            operator: In
+            values: ["true"]
       webhookNames:
         defaulting: "defaulting.clusterimagepolicy.rhtas.com"
         validating: "validating.clusterimagepolicy.rhtas.com"
-      webhookTimeoutSeconds: {}

--- a/config/samples/rhtas.charts_v1alpha1_trustroot.yaml
+++ b/config/samples/rhtas.charts_v1alpha1_trustroot.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: TrustRoot
+metadata:
+  name: trust-root
+spec:
+  remote:
+    mirror: https://tuf.example.com
+    root: | 
+      <base64 encode trust root>

--- a/helm-charts/policy-controller-operator/values.yaml
+++ b/helm-charts/policy-controller-operator/values.yaml
@@ -30,7 +30,11 @@ policy-controller:
       # secrets:
       #   - mys1
       #   - mys2
-    extraArgs: {}
+    extraArgs:
+      webhook-name: policy.rhtas.com
+      mutating-webhook-name: defaulting.clusterimagepolicy.rhtas.com
+      validating-webhook-name: validating.clusterimagepolicy.rhtas.com
+      disable-tuf: true
     resources:
       limits:
         cpu: 200m


### PR DESCRIPTION
Small pr that updates the samples shown when deploying to OCP, all the values are still overridable but I have just left the important ones.

I have also decided to disable tuf by default as when enabled by default the policy-controller will trust the upstreams tuf root, it is possible to configure a custom tuf root by providing a flag and mounting a secret into the policy-controller, however I feel like creating a trust root is a much more straight forward and cleaner approach for custom sigstore instances.

## Summary by Sourcery

Simplify API definitions and samples for the policy-controller operator

Enhancements:
- Add TrustRoot and ClusterImagePolicy sample definitions and include them in CSV examples, kustomization, and sample manifests
- Remove extraneous default fields from PolicyController samples and operator CSV to streamline YAML
- Set disable-tuf to true by default via an extraArg in the Helm chart values