### PR TITLE
Update Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Build the admission-webhook-controller binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467 AS admission-webhook-controller
+FROM registry.redhat.io/ubi9/go-toolset:9.6@sha256:a90b4605b47c396c74de55f574d0f9e03b24ca177dec54782f86cdf702c97dbc AS admission-webhook-controller
 WORKDIR /opt/app-root/src/
+ENV GOEXPERIMENT=strictfipsruntime
+ENV CGO_ENABLED=1
 
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/securesign/policy-controller-operator
 
-go 1.23.6
+go 1.24.0
 
 require (
 	github.com/google/go-containerregistry v0.20.3

--- a/helm-charts/policy-controller-operator/values.yaml
+++ b/helm-charts/policy-controller-operator/values.yaml
@@ -20,7 +20,7 @@ policy-controller:
     name: webhook
     image:
       repository: registry.redhat.io/rhtas/policy-controller-rhel9
-      version: sha256:97d0f4b351308b3656b48f0497272b21625e20b3cf9dd436f5773e63258647ce
+      version: sha256:d67e6b6eeb1fb4acf613c250ef5e549b970314f2ccf552860c8b39d116188a08
       pullPolicy: IfNotPresent
     env: {}
     envFrom: {}


### PR DESCRIPTION
## Summary by Sourcery

Update the Go build environment by switching to the UBI9 Go toolset image, enabling strict FIPS and CGO, and bumping Go to 1.24.0

Enhancements:
- Bump Go version to 1.24.0 in go.mod

Build:
- Switch the Dockerfile base image to registry.redhat.io/ubi9/go-toolset:9.6
- Enable GOEXPERIMENT=strictfipsruntime and CGO_ENABLED=1 in the Dockerfile