### PR TITLE
Update bundle image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ endif
 OPERATOR_SDK_VERSION ?= v1.39.2
 
 # Image URL to use all building/pushing image targets
-IMG ?= registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:c561afee34ee5a43d78b5fe562de3d7777530865a3ae63f4e04920c424991364
+IMG ?= registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:0df1d7bc0d437207db49eed60b5b3c5659c72adb11665d08f98034ddd2935d17
 
 # CONTAINER_TOOL defines the container tool to be used for building images.
 # Be aware that the target commands are only tested with Docker which is

--- a/bundle/manifests/policy-controller-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/policy-controller-operator.clusterserviceversion.yaml
@@ -89,8 +89,8 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:c561afee34ee5a43d78b5fe562de3d7777530865a3ae63f4e04920c424991364
-    createdAt: "2025-06-27T10:05:26Z"
+    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:0df1d7bc0d437207db49eed60b5b3c5659c72adb11665d08f98034ddd2935d17
+    createdAt: "2025-07-24T11:02:08Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -266,7 +266,7 @@ spec:
                 - --leader-elect
                 - --leader-election-id=policy-controller-operator
                 - --health-probe-bind-address=:8081
-                image: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:c561afee34ee5a43d78b5fe562de3d7777530865a3ae63f4e04920c424991364
+                image: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:0df1d7bc0d437207db49eed60b5b3c5659c72adb11665d08f98034ddd2935d17
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -294,7 +294,7 @@ spec:
                     - ALL
               - command:
                 - admission-webhook-controller
-                image: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:c561afee34ee5a43d78b5fe562de3d7777530865a3ae63f4e04920c424991364
+                image: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:0df1d7bc0d437207db49eed60b5b3c5659c72adb11665d08f98034ddd2935d17
                 name: admission-webhook-controller
                 ports:
                 - containerPort: 9443

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:c561afee34ee5a43d78b5fe562de3d7777530865a3ae63f4e04920c424991364
+- digest: sha256:0df1d7bc0d437207db49eed60b5b3c5659c72adb11665d08f98034ddd2935d17
   name: controller
   newName: registry.redhat.io/rhtas/policy-controller-rhel9-operator

--- a/config/manifests/bases/policy-controller-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/policy-controller-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:c561afee34ee5a43d78b5fe562de3d7777530865a3ae63f4e04920c424991364
+    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:0df1d7bc0d437207db49eed60b5b3c5659c72adb11665d08f98034ddd2935d17
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"


### PR DESCRIPTION
## Summary by Sourcery

Bump policy-controller-operator image to new SHA digest and sync it across bundle, base manifests, kustomization, and Makefile, including updating the CSV createdAt timestamp

Chores:
- Update operator bundle CSV containerImage digest and createdAt timestamp
- Update CSV spec container image references for controller and webhook
- Update default image digest in Makefile
- Update kustomization and base manifests with new image digest