### PR TITLE
ci: add local bin env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,11 @@ CONTAINER_TOOL ?= docker
 #   false - deploy with the generic Kubernetes overlay in config/deploy
 OPENSHIFT ?= true
 
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
 .PHONY: all
 all: docker-build
 


### PR DESCRIPTION
## Summary by Sourcery

Add support for a local bin directory in the Makefile for dependency installation

Enhancements:
- Introduce LOCALBIN variable defaulting to ./bin
- Create a Makefile target to ensure the LOCALBIN directory exists before use