### PR TITLE
:robot: [RHTAS-build-bot] [add-localbin-env] Update Operator Bundle Controller Image

### DIFF
--- a/bundle/manifests/policy-controller-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/policy-controller-operator.clusterserviceversion.yaml
@@ -89,8 +89,8 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:0df1d7bc0d437207db49eed60b5b3c5659c72adb11665d08f98034ddd2935d17
-    createdAt: "2025-07-24T11:02:08Z"
+    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:58d225170cd42e2a1dadaf7bf170c2f9cc33c7e3cfac9be87e80a8c95f0db83e
+    createdAt: "2025-08-11T10:39:58Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/config/manifests/bases/policy-controller-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/policy-controller-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:0df1d7bc0d437207db49eed60b5b3c5659c72adb11665d08f98034ddd2935d17
+    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:58d225170cd42e2a1dadaf7bf170c2f9cc33c7e3cfac9be87e80a8c95f0db83e
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/policy-controller-rhel9-operator | 0df1d7b | 58d2251 |
---

## Summary by Sourcery

Enhancements:
- Refresh registry.redhat.io/policy-controller-rhel9-operator containerImage SHA and createdAt date in both bundle and base CSV files