### PR TITLE
:robot: [RHTAS-build-bot] [main] Update Operator Bundle Controller Image

### DIFF
--- a/bundle/manifests/policy-controller-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/policy-controller-operator.clusterserviceversion.yaml
@@ -89,8 +89,8 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:58d225170cd42e2a1dadaf7bf170c2f9cc33c7e3cfac9be87e80a8c95f0db83e
-    createdAt: "2025-08-11T10:42:04Z"
+    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:47dbd3ea6fd88503ee4335cc43df9be2d4829d7c285fcb54b401dcc31cfe450b
+    createdAt: "2025-08-18T14:10:07Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/config/manifests/bases/policy-controller-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/policy-controller-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:58d225170cd42e2a1dadaf7bf170c2f9cc33c7e3cfac9be87e80a8c95f0db83e
+    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:47dbd3ea6fd88503ee4335cc43df9be2d4829d7c285fcb54b401dcc31cfe450b
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/policy-controller-rhel9-operator | 58d2251 | 47dbd3e |
---

## Summary by Sourcery

Update the policy-controller operator bundle manifests to reference the new container image SHA and adjust the createdAt timestamp.

Chores:
- Update containerImage SHA in both bundle and base CSV manifests to the new operator image
- Adjust createdAt timestamp in the bundle CSV to match the updated image