### PR TITLE
Update channel and version name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.0.0
+VERSION ?= 0.0.1-techpreview
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -5,7 +5,7 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=policy-controller-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channels.v1=tech-preview
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.39.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=helm.sdk.operatorframework.io/v1
@@ -18,7 +18,7 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL vendor="Red Hat, Inc."
 LABEL url="https://www.redhat.com"
 LABEL distribution-scope="public"
-LABEL version="1.0.0"
+LABEL version="0.0.1-techpreview"
 
 LABEL description="The bundle image for the policy-controller-operator, containing manifests, metadata and testing scorecard."
 LABEL io.k8s.description="The bundle image for the policy-controller-operator, containing manifests, metadata and testing scorecard."

--- a/bundle/manifests/policy-controller-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/policy-controller-operator.clusterserviceversion.yaml
@@ -90,7 +90,7 @@ metadata:
       ]
     capabilities: Basic Install
     containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:47dbd3ea6fd88503ee4335cc43df9be2d4829d7c285fcb54b401dcc31cfe450b
-    createdAt: "2025-08-18T14:10:07Z"
+    createdAt: "2025-08-18T14:52:34Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -106,7 +106,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/securesign/policy-controller-operator
     support: Red Hat
-  name: policy-controller-operator.v1.0.0
+  name: policy-controller-operator.v0.0.1-techpreview
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -375,10 +375,10 @@ spec:
   maintainers:
   - email: japower@redhat.com
     name: Jason Power
-  maturity: stable
+  maturity: tech-preview
   provider:
     name: Red Hat
-  version: 1.0.0
+  version: 0.0.1-techpreview
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,7 +4,7 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: policy-controller-operator
-  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: tech-preview
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.39.2
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1

--- a/config/manifests/bases/policy-controller-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/policy-controller-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     operators.openshift.io/valid-subscription: '["Red Hat Trusted Artifact Signer"]'
     repository: https://github.com/securesign/policy-controller-operator
     support: Red Hat
-  name: policy-controller-operator.v1.0.0
+  name: policy-controller-operator.v0.0.1-techpreview
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -79,7 +79,7 @@ spec:
   maintainers:
   - email: japower@redhat.com
     name: Jason Power
-  maturity: stable
+  maturity: tech-preview
   provider:
     name: Red Hat
-  version: 1.0.0
+  version: 0.0.1-techpreview


### PR DESCRIPTION
## Summary by Sourcery

Prepare a tech-preview release by updating the operator version, maturity, default channel, and associated metadata

Enhancements:
- Bump operator version from 1.0.0 to 0.0.1-techpreview and reflect this in CSV, Dockerfile, Makefile, and annotations
- Update maturity designation to tech-preview and switch the default OLM bundle channel from stable to tech-preview
- Refresh the CSV createdAt timestamp to align with the new release