### PR TITLE
:robot: [RHTAS-build-bot] [main] Update Operator Bundle Controller Image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ endif
 OPERATOR_SDK_VERSION ?= v1.39.2
 
 # Image URL to use all building/pushing image targets
-IMG ?= registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:0df1d7bc0d437207db49eed60b5b3c5659c72adb11665d08f98034ddd2935d17
+IMG ?= registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:655330f7a5bf64e79b9c1a63930e48531a42052d850d2eb540a6c87a9105b329
 
 # CONTAINER_TOOL defines the container tool to be used for building images.
 # Be aware that the target commands are only tested with Docker which is

--- a/bundle/manifests/policy-controller-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/policy-controller-operator.clusterserviceversion.yaml
@@ -89,8 +89,8 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:2a912eea75369043bd474d1465188d5272ea9ce464298e504a3c542dc2da7775
-    createdAt: "2025-08-20T10:26:53Z"
+    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:655330f7a5bf64e79b9c1a63930e48531a42052d850d2eb540a6c87a9105b329
+    createdAt: "2025-08-20T11:15:33Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -266,7 +266,7 @@ spec:
                 - --leader-elect
                 - --leader-election-id=policy-controller-operator
                 - --health-probe-bind-address=:8081
-                image: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:0df1d7bc0d437207db49eed60b5b3c5659c72adb11665d08f98034ddd2935d17
+                image: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:655330f7a5bf64e79b9c1a63930e48531a42052d850d2eb540a6c87a9105b329
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -294,7 +294,7 @@ spec:
                     - ALL
               - command:
                 - admission-webhook-controller
-                image: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:0df1d7bc0d437207db49eed60b5b3c5659c72adb11665d08f98034ddd2935d17
+                image: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:655330f7a5bf64e79b9c1a63930e48531a42052d850d2eb540a6c87a9105b329
                 name: admission-webhook-controller
                 ports:
                 - containerPort: 9443

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:0df1d7bc0d437207db49eed60b5b3c5659c72adb11665d08f98034ddd2935d17
+- digest: sha256:655330f7a5bf64e79b9c1a63930e48531a42052d850d2eb540a6c87a9105b329
   name: controller
   newName: registry.redhat.io/rhtas/policy-controller-rhel9-operator

--- a/config/manifests/bases/policy-controller-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/policy-controller-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:2a912eea75369043bd474d1465188d5272ea9ce464298e504a3c542dc2da7775
+    containerImage: registry.redhat.io/rhtas/policy-controller-rhel9-operator@sha256:655330f7a5bf64e79b9c1a63930e48531a42052d850d2eb540a6c87a9105b329
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/policy-controller-rhel9-operator | 2a912ee | 655330f |
---

## Summary by Sourcery

Update policy-controller-operator bundle and configuration to reference the new operator image digest

Build:
- Bump operator image digest in Makefile, manager kustomization, and CSV manifests

Chores:
- Update createdAt timestamp in the bundle CSV to match the new image build time