### PR TITLE
Enable codecov coverage checks

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches: [ "main", "release*" ]
 
-env:
-  GO_VERSION: 1.24.0
-
 jobs:
   coverage:
     name: Upload Code Coverage
@@ -18,13 +15,13 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Run tests with coverage
         run: cd cmd && go test -count=1 -coverprofile=coverage.out ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: cmd/coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,31 @@
+name: Code Coverage
+
+on:
+  pull_request:
+    branches: [ "main", "release*" ]
+
+env:
+  GO_VERSION: 1.24.0
+
+jobs:
+  coverage:
+    name: Upload Code Coverage
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run tests with coverage
+        run: cd cmd && go test -count=1 -coverprofile=coverage.out ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: cmd/coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ bin
 *.swo
 *~
 
+# coverage
+coverage.out
+
 # testing
 CatalogSource.yaml
 test/Dockerfile

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        informational: true
+    patch:
+      default:
+        target: 70%
+        threshold: 5%


### PR DESCRIPTION
## Summary
- Add `codecov.yml` with coverage status checks for PRs
- Create `.github/workflows/code-coverage.yml` to run tests with coverage and upload to Codecov

## Coverage checks configured

| Check | Target | Behavior |
|-------|--------|----------|
| **Patch** (new/changed lines) | 70% with 5% threshold | Fails PR if coverage of changed lines is below 65% |
| **Project** (overall codebase) | auto (current coverage) | Informational only — will not block PRs |

## Workflow details
A new `code-coverage.yml` workflow runs on pull requests to `main` and `release*` branches. It:
1. Checks out the code and sets up Go
2. Runs `go test -coverprofile` on the `cmd/` package
3. Uploads the coverage report to Codecov using `codecov/codecov-action@v5`

A separate workflow was created (rather than modifying `main.yml`) to keep coverage concerns isolated from the existing validation pipeline.

## Required setup: CODECOV_TOKEN

A `CODECOV_TOKEN` secret must be configured in the repository for the Codecov upload to succeed:

1. Go to [codecov.io](https://about.codecov.io/) and sign in with GitHub
2. Add the `securesign/policy-controller-operator` repository
3. Copy the upload token from **Settings → General → Repository Upload Token**
4. In GitHub, go to **Settings → Secrets and variables → Actions → New repository secret**
5. Create a secret named `CODECOV_TOKEN` with the token value

## Test plan
- [ ] Verify the `Code Coverage` workflow triggers on a PR to `main`
- [ ] Verify tests run with `-coverprofile` and produce `coverage.out`
- [ ] Verify `CODECOV_TOKEN` is configured and the upload succeeds
- [ ] Verify Codecov posts patch and project coverage status checks on the PR
- [ ] Verify patch coverage below 65% blocks the PR
- [ ] Verify project coverage is informational and does not block the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

ref: https://redhat.atlassian.net/browse/SECURESIGN-4381