### PR TITLE
ci: switch codecov to OIDC auth and add coverage flags

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,8 +1,14 @@
 name: Code Coverage
 
 on:
+  push:
+    branches: [ "main", "release*" ]
   pull_request:
     branches: [ "main", "release*" ]
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   coverage:
@@ -24,5 +30,6 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           files: cmd/coverage.out
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
+          flags: unit-tests
           fail_ci_if_error: true

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches: [ "main", "release*" ]
 
-env:
-  GO_VERSION: 1.24.0
-
 jobs:
   coverage:
     name: Upload Code Coverage
@@ -18,13 +15,13 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Run tests with coverage
         run: cd cmd && go test -count=1 -coverprofile=coverage.out ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: cmd/coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,31 @@
+name: Code Coverage
+
+on:
+  pull_request:
+    branches: [ "main", "release*" ]
+
+env:
+  GO_VERSION: 1.24.0
+
+jobs:
+  coverage:
+    name: Upload Code Coverage
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run tests with coverage
+        run: cd cmd && go test -count=1 -coverprofile=coverage.out ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: cmd/coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ bin
 *.swo
 *~
 
+# coverage
+coverage.out
+
 # testing
 CatalogSource.yaml
 test/Dockerfile

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,18 @@ coverage:
       default:
         target: 70%
         threshold: 5%
+
+flags:
+  unit-tests:
+    paths:
+      - cmd/
+    carryforward: true
+
+flag_management:
+  individual_flags:
+    - name: unit-tests
+      statuses:
+        - type: project
+          target: auto
+        - type: patch
+          target: 70%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        informational: true
+    patch:
+      default:
+        target: 70%
+        threshold: 5%


### PR DESCRIPTION
## Summary

- Switch Codecov authentication from token-based (`CODECOV_TOKEN`) to OIDC (`use_oidc: true`) for this public repository
- Add `unit-tests` coverage flag to uploads and define flag analytics in `codecov.yml`
- Add `push` trigger on `main` and `release*` branches for baseline coverage uploads
- Add required `id-token: write` and `contents: read` permissions for OIDC

Implements [SECURESIGN-4442](https://redhat.atlassian.net/browse/SECURESIGN-4442)

Legacy context: [SECURESIGN-4381](https://redhat.atlassian.net/browse/SECURESIGN-4381)

Epic: [COVERPORT-197](https://redhat.atlassian.net/browse/COVERPORT-197)

## Test plan

- [x] Verify OIDC authentication works for coverage upload (push to main or open PR)
- [x] Confirm coverage report appears at https://app.codecov.io/gh/securesign/policy-controller-operator
- [x] Verify `unit-tests` flag is visible in Codecov flag analytics
- [ ] Confirm PR coverage comments show flag-level breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)