### PR TITLE
Update release-version to 1.5.0

### DIFF
--- a/.tekton/policy-controller-operator-bundle-pull-request.yaml
+++ b/.tekton/policy-controller-operator-bundle-pull-request.yaml
@@ -48,7 +48,7 @@ spec:
   - name: image-version
     value: "1.1.0"
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   pipelineRef:
     params:
     - name: url

--- a/.tekton/policy-controller-operator-bundle-push.yaml
+++ b/.tekton/policy-controller-operator-bundle-push.yaml
@@ -45,7 +45,7 @@ spec:
   - name: image-version
     value: "1.1.0"
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   pipelineRef:
     params:
     - name: url

--- a/.tekton/policy-controller-operator-pull-request.yaml
+++ b/.tekton/policy-controller-operator-pull-request.yaml
@@ -46,7 +46,7 @@ spec:
   - name: image-version
     value: "1.1.0"
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   pipelineRef:
     params:
     - name: url

--- a/.tekton/policy-controller-operator-push.yaml
+++ b/.tekton/policy-controller-operator-push.yaml
@@ -43,7 +43,7 @@ spec:
   - name: image-version
     value: "1.1.0"
   - name: release-version
-    value: "1.4.0"
+    value: "1.5.0"
   pipelineRef:
     params:
     - name: url


### PR DESCRIPTION
## Summary
- Update `release-version` parameter from `1.4.0` to `1.5.0` in all `.tekton` pipeline definitions

## Test plan
- [ ] Verify Tekton pipeline definitions are valid YAML
- [ ] Confirm `release-version` is set to `1.5.0` in all pipeline files

🤖 Generated with [Claude Code](https://claude.com/claude-code)